### PR TITLE
Immediately execute Punchy and LhUpdateWorker

### DIFF
--- a/lighthouse.go
+++ b/lighthouse.go
@@ -338,11 +338,13 @@ func (lh *LightHouse) LhUpdateWorker(ctx context.Context, f EncWriter) {
 	defer clockSource.Stop()
 
 	for {
+		lh.SendUpdate(f)
+
 		select {
 		case <-ctx.Done():
 			return
 		case <-clockSource.C:
-			lh.SendUpdate(f)
+			continue
 		}
 	}
 }


### PR DESCRIPTION
@briankelly reported that new builds of dnclient were taking 60 seconds to report to the Lighthouse.

https://github.com/DefinedNet/nebula/pull/1 (72b92e05db8f747364bd5e2f98477ac310617cc2a) introduced a change that
allowed us to clean up various goroutines in the Nebula process from a
controlling process. This change involved updating some Sleep lines to
Ticker objects.

However a couple loops were changed from "execute immediately and then
every X seconds" to "wait X seconds and then repeat every X seconds".

This makes sure we execute those two routines immediately.

@briankelly reports this solved the issue.